### PR TITLE
[Auth] Allow auth via secrets too and update docs for this.

### DIFF
--- a/docs/Configure the sample site.md
+++ b/docs/Configure the sample site.md
@@ -67,7 +67,7 @@ Follow these steps to configure the sample site before running it.
 ```
 
 ## Note: Authenticating with a password rather than a certificate
-We recommend authenticating via certificate. If you want or need to authenticate via a secret (password) instead, select "Secret" on the Real Time APIs page instead of "Certificate". Then, copy the secret from the confirmation page and set it as the value for the "ClientSecret" setting in your appsettings.json file. For non sample apps, you would want to securely inject that secret into the application rather than having it hard-coded into your appsettings file.
+We recommend authenticating via certificate. If you want or need to authenticate via a secret (password) instead, select "Secret" on the Real Time APIs page instead of "Certificate," then copy the secret from the confirmation page and set it as the value for the "ClientSecret" setting in your appsettings.json file. For non-sample apps, you would want to securely inject that secret into the application rather than having it hard-coded into your appsettings file.
 
 ## More info
-Read [integrate real-time APIs](https://go.microsoft.com/fwlink/?linkid=2085128) for generalized information on configuring API access. The steps are nearly identical, but do not discuss the sample site's specific configuration file.
+Read [integrate real-time APIs](https://go.microsoft.com/fwlink/?linkid=2085128) for general information on configuring API access. The steps are nearly identical, but do not discuss the sample site's specific configuration file.

--- a/docs/Configure the sample site.md
+++ b/docs/Configure the sample site.md
@@ -28,9 +28,6 @@ Follow these steps to configure the sample site before running it.
    1. Install the matching private key on your local machine (or wherever you will run the sample site from) and place it in the "Current User" certificate store.
 1. You've finished configuring the sample site. You can now run the sample site, which will make calls to the Dynamics 365 Fraud Protection APIs.
 
-## Note: Authenticating with a password rather than a certificate
-This sample application authenticates via a client ID/certificate pair. Using a client ID/password pair is also possible by using the ```ClientCredential``` C# class rather than the ```ClientAssertionCertificate``` class as in the TokenProviderService sample below. In this scenario, you would also create another AAD application using the Real Time APIs page, but select "Secret" as the authentication method. You would then need to safely and securely get that secret into the application.
-
 ## Example: final appsettings.json
 ```json
 {
@@ -61,9 +58,16 @@ This sample application authenticates via a client ID/certificate pair. Using a 
     },
     "TokenProviderConfig": {
       "ClientId": "00112233-4455-6677-8899-aabbccddeefg",
-      "Authority": "https://login.microsoftonline.com/contoso.onmicrosoft.com",
-      "CertificateThumbprint": "934367bf1c97033f877db0f15cb1b586957d313"
+      "Authority": "https://login.microsoftonline.com/11112222-3333-4444-5555-666677778888",
+      "CertificateThumbprint": "111122223333444455556666777788889999000",
+      "ClientSecret": ""
     }
   }
 }
 ```
+
+## Note: Authenticating with a password rather than a certificate
+We recommend authenticating via certificate. If you want or need to authenticate via a secret (password) instead, select "Secret" on the Real Time APIs page instead of "Certificate". Then, copy the secret from the confirmation page and set it as the value for the "ClientSecret" setting in your appsettings.json file. For non sample apps, you would want to securely inject that secret into the application rather than having it hard-coded into your appsettings file.
+
+## More info
+Read [integrate real-time APIs](https://go.microsoft.com/fwlink/?linkid=2085128) for generalized information on configuring API access. The steps are nearly identical, but do not discuss the sample site's specific configuration file.

--- a/src/Infrastructure/Services/FraudProtectionSettings.cs
+++ b/src/Infrastructure/Services/FraudProtectionSettings.cs
@@ -25,6 +25,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
         public string ClientId { get; set; }
         public string Authority { get; set; }
 		public string CertificateThumbprint { get; set; }
+		public string ClientSecret { get; set; }
 	}
     #endregion
 }

--- a/src/Infrastructure/Utilities/CertificateUtility.cs
+++ b/src/Infrastructure/Utilities/CertificateUtility.cs
@@ -8,12 +8,12 @@ namespace Contoso.FraudProtection.Infrastructure.Utilities
 {
     public static class CertificateUtility
     {
-        public static X509Certificate2 GetCertificateBy<T>(X509FindType findType, T findValue, bool findValidOnly = true)
+        public static X509Certificate2 GetCertificateBy<T>(X509FindType findType, T findValue)
         {
             var certStore = new X509Store(StoreLocation.CurrentUser);
             certStore.Open(OpenFlags.ReadOnly);
 
-            X509Certificate2Collection certs = certStore.Certificates.Find(findType, findValue, findValidOnly);
+            X509Certificate2Collection certs = certStore.Certificates.Find(findType, findValue, false);
             if(certs.Count > 0)
             {
                 return certs[0];
@@ -22,11 +22,6 @@ namespace Contoso.FraudProtection.Infrastructure.Utilities
             {
                 throw new Exception("Certificate is missing from your current user storage.");
             }
-        }
-
-        public static X509Certificate2 GetCertificateByName(string certName)
-        {
-            return GetCertificateBy(X509FindType.FindBySubjectDistinguishedName, certName);
         }
 
         public static X509Certificate2 GetByThumbprint(string thumbprint)

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "ConnectionStrings": {
-    "CatalogConnection": "<Optional. By default, the app uses an in-memory DB. You only need to set this if you change the app to not use the in memory DB. DB connection string here or inject it at runtime with a secrets manager. Always store secrets securely.>",
-    "IdentityConnection": "<Optional. By default, the app uses an in-memory DB. You only need to set this if you change the app to not use the in memory DB. DB connection string here or inject it at runtime with a secrets manager. Always store secrets securely.>"
+    "CatalogConnection": "", //Optional. By default, the app uses an in-memory DB. You only need to set this if you change the app to not use the in memory DB. DB connection string here or inject it at runtime with a secrets manager. Always store secrets securely.
+    "IdentityConnection": "" //Optional. By default, the app uses an in-memory DB. You only need to set this if you change the app to not use the in memory DB. DB connection string here or inject it at runtime with a secrets manager. Always store secrets securely.
   },
   "CatalogBaseUrl": "",
   "Logging": {
@@ -13,9 +13,9 @@
     }
   },
   "FraudProtectionSettings": {
-    "DeviceFingerprintingDomain": "<Your device fingerprinting domain that you have created. More info: https://docs.microsoft.com/en-us/dynamics365/fraud-protection/device-fingerprinting#set-up-azure-dns>",
-    "DeviceFingerprintingCustomerId": "<Your Microsoft device fingerprinting customer ID. Typically your Instance ID from the Dynamics 365 Fraud Protection portal dashboard.>",
-    "ApiBaseUrl": "https://api.dfp.microsoft-int.com",
+    "DeviceFingerprintingDomain": "", //Your device fingerprinting domain that you have created. More info: https://docs.microsoft.com/en-us/dynamics365/fraud-protection/device-fingerprinting#set-up-azure-dns
+    "DeviceFingerprintingCustomerId": "", //Your Microsoft device fingerprinting customer ID. Typically your Instance ID from the Dynamics 365 Fraud Protection portal dashboard.
+    "ApiBaseUrl": "https://api.dfp.microsoft-int.com", //Remove '-int' to call the production API instead.
     "Endpoints": {
       "Purchase": "/v0.5/MerchantServices/events/Purchase",
       "PurchaseStatus": "/v0.5/MerchantServices/events/PurchaseStatus",
@@ -26,9 +26,11 @@
     },
 
     "TokenProviderConfig": {
-      "ClientId": "<Your Fraud Protection merchant Azure Active Directory client app ID>",
-      "Authority": "<Your Fraud Protection merchant Azure Active Directory tenant authority URL>",
-      "CertificateThumbprint": "<The thumbprint of the certificate to use to authenticate against your merchant Azure Active Directory client app>"
+      "ClientId": "", //<Your Fraud Protection merchant Azure Active Directory client app ID>",
+      "Authority": "", //<Your Fraud Protection merchant Azure Active Directory tenant authority URL>",
+      //Only set 1 of the 2 below depending on if you authenticate with a certificate or a secret (password).
+      "CertificateThumbprint": "", //<The thumbprint of the certificate to use to authenticate against your merchant Azure Active Directory client app.
+      "ClientSecret": "" //<The secret for your merchant Azure Active Directory client app. Inject it at runtime with a secrets manager. Always store secrets securely.
     }
   }
 }


### PR DESCRIPTION
This PR allows the sample site to authenticate with DFP via a secret (password) in addition to its existing support for authenticating with a certificate.  The PR also updates documentation related to these changes.