### PR TITLE
Remove JSON.NET and use System.Text.Json instead.

### DIFF
--- a/src/ApplicationCore/ApplicationCore.csproj
+++ b/src/ApplicationCore/ApplicationCore.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="1.4.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Address.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Address.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
 {
     public class Address
     {
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public AddressType AddressType { get; set; }
 
         public string FirstName { get; set; }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/CustomerEmail.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/CustomerEmail.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
 {
     public class CustomerEmail
     {
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public EmailType EmailType { get; set; }
 
         public string EmailValue { get; set; }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/CustomerPhone.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/CustomerPhone.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
 {
     public class CustomerPhone
     {
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public PhoneType PhoneType { get; set; }
 
         public string PhoneNumber { get; set; }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Responses/ResultDetail.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Responses/ResultDetail.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System.Collections.Generic;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
 {
     public class ResultDetail
     {
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public DecisionName Decision { get; set; }
 
         public string ChallengeType { get; set; }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/SignIn.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/SignIn.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.Dynamics.FraudProtection.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
@@ -30,7 +29,7 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
 
         public DateTimeOffset CustomerLocalDate { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public AssessmentType AssessmentType { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Signup.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Signup.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.Dynamics.FraudProtection.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using System;
 using System.Collections.Generic;
 
@@ -37,7 +36,7 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
 
         public DateTimeOffset CustomerLocalDate { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public AssessmentType AssessmentType { get; set; }
     }
 }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/User.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/User.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection
 {
@@ -10,7 +9,7 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
     {
         public string UserId { get; set; }
 
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public UserType UserType { get; set; }
 
         public string Username { get; set; }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/BaseFraudProtectionEvent.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/BaseFraudProtectionEvent.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
 using System;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Dynamics.FraudProtection.Models
 {
     public abstract class BaseFraudProtectionEvent : IBaseFraudProtectionEvent
     {
         // Inlining to avoid multi-inheritance but still take advantage of shared UserDetails
-        [JsonProperty(PropertyName = "_metadata")]
+        [JsonPropertyName("_metadata")]
         public EventMetadata Metadata { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/PurchaseResponse.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/PurchaseResponse.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels
 {
     public class PurchaseResponse
     {
-        [JsonProperty("resultDetails")]
+        [JsonPropertyName("resultDetails")]
         public PurchaseResultDetails ResultDetails { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SignInResponse.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SignInResponse.cs
@@ -1,13 +1,10 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Text.Json.Serialization;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response
 {
     public class SignInResponse
     {
-        [JsonProperty("resultDetails")]
+        [JsonPropertyName("resultDetails")]
         public SignInResponseDetails ResultDetails { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SignupResponse.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SignupResponse.cs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
+
+using System.Text.Json.Serialization;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels
 {
     public class SignupResponse
     {
-        [JsonProperty("resultDetails")]
+        [JsonPropertyName("resultDetails")]
         public SignupResponseDetails ResultDetails { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/UpdateAccount.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/UpdateAccount.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Dynamics.FraudProtection.Models.UpdateAccountEvent
 {
@@ -28,7 +28,7 @@ namespace Microsoft.Dynamics.FraudProtection.Models.UpdateAccountEvent
         public DeviceContext DeviceContext { get; set; }
 
         // Inlining to avoid multi-inheritance but still take advantage of shared UserDetails
-        [JsonProperty(PropertyName = "_metadata")]
+        [JsonPropertyName("_metadata")]
         public EventMetadata Metadata { get; set; }
     }
 

--- a/src/ApplicationCore/Entities/OrderAggregate/Order.cs
+++ b/src/ApplicationCore/Entities/OrderAggregate/Order.cs
@@ -7,12 +7,12 @@ using Microsoft.Dynamics.FraudProtection.Models.RefundEvent;
 using Microsoft.Dynamics.FraudProtection.Models.ChargebackEvent;
 using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels;
 using Contoso.FraudProtection.ApplicationCore.Interfaces;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using Contoso.FraudProtection.ApplicationCore.Services;
 using System.Linq;
+using System.Text.Json;
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
 {
@@ -71,11 +71,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskPurchase) ? null : JsonConvert.DeserializeObject<Purchase>(_riskPurchase);
+                return string.IsNullOrEmpty(_riskPurchase) ? null : JsonSerializer.Deserialize<Purchase>(_riskPurchase);
             }
             set
             {
-                _riskPurchase = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskPurchase = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 
@@ -84,11 +84,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskRefund) ? null : JsonConvert.DeserializeObject<Refund>(_riskRefund);
+                return string.IsNullOrEmpty(_riskRefund) ? null : JsonSerializer.Deserialize<Refund>(_riskRefund);
             }
             set
             {
-                _riskRefund = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskRefund = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 
@@ -97,11 +97,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskRefundResponse) ? null : JsonConvert.DeserializeObject<FraudProtectionResponse>(_riskRefundResponse);
+                return string.IsNullOrEmpty(_riskRefundResponse) ? null : JsonSerializer.Deserialize<FraudProtectionResponse>(_riskRefundResponse);
             }
             set
             {
-                _riskRefundResponse = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskRefundResponse = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 
@@ -110,11 +110,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskChargeback) ? null : JsonConvert.DeserializeObject<Chargeback>(_riskChargeback);
+                return string.IsNullOrEmpty(_riskChargeback) ? null : JsonSerializer.Deserialize<Chargeback>(_riskChargeback);
             }
             set
             {
-                _riskChargeback = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskChargeback = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 
@@ -123,11 +123,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskChargebackResponse) ? null : JsonConvert.DeserializeObject<FraudProtectionResponse>(_riskChargebackResponse);
+                return string.IsNullOrEmpty(_riskChargebackResponse) ? null : JsonSerializer.Deserialize<FraudProtectionResponse>(_riskChargebackResponse);
             }
             set
             {
-                _riskChargebackResponse = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskChargebackResponse = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 
@@ -136,11 +136,11 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.OrderAggregate
         {
             get
             {
-                return string.IsNullOrEmpty(_riskPurchaseResponse) ? null : JsonConvert.DeserializeObject<PurchaseResponse>(_riskPurchaseResponse);
+                return string.IsNullOrEmpty(_riskPurchaseResponse) ? null : JsonSerializer.Deserialize<PurchaseResponse>(_riskPurchaseResponse);
             }
             set
             {
-                _riskPurchaseResponse = value != null ? JsonConvert.SerializeObject(value) : null;
+                _riskPurchaseResponse = value != null ? JsonSerializer.Serialize(value) : null;
             }
         }
 

--- a/src/Infrastructure/Services/FraudProtectionService.cs
+++ b/src/Infrastructure/Services/FraudProtectionService.cs
@@ -36,7 +36,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
         private readonly HttpClient _httpClient;
         private readonly ITokenProvider _tokenProviderService;
         private readonly FraudProtectionSettings _settings;
-        private readonly JsonSerializerOptions _requestSerializtionOptions;
+        private readonly JsonSerializerOptions _requestSerializationOptions;
         private readonly JsonSerializerOptions _responseDeserializationOptions;
 
         public FraudProtectionService(IOptions<FraudProtectionSettings> settings, ITokenProvider tokenProviderService)
@@ -44,7 +44,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
             _httpClient = new HttpClient();
             _settings = settings.Value;
             _tokenProviderService = tokenProviderService;
-            _requestSerializtionOptions = new JsonSerializerOptions
+            _requestSerializationOptions = new JsonSerializerOptions
             {
                 IgnoreNullValues = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -74,7 +74,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
 
             var authToken = await _tokenProviderService.AcquireTokenAsync();
             var url = $"{_settings.ApiBaseUrl}{endpoint}";
-            var serializedObject = JsonSerializer.Serialize(content, _requestSerializtionOptions);
+            var serializedObject = JsonSerializer.Serialize(content, _requestSerializationOptions);
             var serializedContent = new StringContent(serializedObject, Encoding.UTF8, "application/json");
 
             return await _httpClient.PostWithHeadersAsync(

--- a/src/Infrastructure/Services/FraudProtectionService.cs
+++ b/src/Infrastructure/Services/FraudProtectionService.cs
@@ -36,7 +36,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
         private readonly ITokenProvider _tokenProviderService;
         private readonly FraudProtectionSettings _settings;
         private readonly JsonSerializerOptions _requestSerializtionOptions;
-        private readonly JsonSerializerOptions _responseDeserializtionOptions;
+        private readonly JsonSerializerOptions _responseDeserializationOptions;
 
         public FraudProtectionService(IOptions<FraudProtectionSettings> settings, ITokenProvider tokenProviderService)
         {
@@ -48,7 +48,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
                 IgnoreNullValues = true,
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
-            _responseDeserializtionOptions = new JsonSerializerOptions
+            _responseDeserializationOptions = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true
             };
@@ -94,7 +94,7 @@ namespace Contoso.FraudProtection.Infrastructure.Services
             var rawContent = await rawResponse.Content.ReadAsStringAsync();
             rawResponse.Dispose();
 
-            return JsonSerializer.Deserialize<T>(rawContent, _responseDeserializtionOptions);
+            return JsonSerializer.Deserialize<T>(rawContent, _responseDeserializationOptions);
         }
 
         public async Task<PurchaseResponse> PostPurchase(Purchase purchase, string correlationId = null)

--- a/src/Web/Controllers/AccountController.cs
+++ b/src/Web/Controllers/AccountController.cs
@@ -150,8 +150,7 @@ namespace Contoso.FraudProtection.Web.Controllers
                 var fraudProtectionIO = new FraudProtectionIOModel(signIn, signInResponse, "SignIn");
                 TempData.Put(FraudProtectionIOModel.TempDataKey, fraudProtectionIO);
 
-                AccountProtection.ResponseSuccess response = signInResponse as AccountProtection.ResponseSuccess;
-                if (response != null)
+                if (signInResponse is AccountProtection.ResponseSuccess response)
                 {
                     rejectSignIn = response.ResultDetails.FirstOrDefault()?.Decision != AccountProtection.DecisionName.Approve;
                 }
@@ -329,8 +328,7 @@ namespace Contoso.FraudProtection.Web.Controllers
                 TempData.Put(FraudProtectionIOModel.TempDataKey, fraudProtectionIO);
 
                 bool rejectSignup = false;
-                AccountProtection.ResponseSuccess signupResponse = signupAssessment as AccountProtection.ResponseSuccess;
-                if (signupResponse != null)
+                if (signupAssessment is AccountProtection.ResponseSuccess signupResponse)
                 {
                     rejectSignup = signupResponse.ResultDetails.FirstOrDefault()?.Decision != AccountProtection.DecisionName.Approve;
                 }

--- a/src/Web/Controllers/BasketController.cs
+++ b/src/Web/Controllers/BasketController.cs
@@ -320,7 +320,7 @@ namespace Contoso.FraudProtection.Web.Controllers
                 Provider = DeviceContextProvider.DFPFingerPrinting.ToString()
             };
 
-            Func<string, string> getCategoryFromName = (productName) =>
+            static string getCategoryFromName(string productName)
             {
                 if (productName.Contains("mug", StringComparison.InvariantCultureIgnoreCase))
                 {
@@ -338,7 +338,7 @@ namespace Contoso.FraudProtection.Web.Controllers
                 }
 
                 return "Other";
-            };
+            }
 
             var productList = basketViewModel.Items
                 .Select(i => new Product

--- a/src/Web/Extensions/TempDataExtensions.cs
+++ b/src/Web/Extensions/TempDataExtensions.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Contoso.FraudProtection.Web.Extensions
 {
@@ -10,13 +10,13 @@ namespace Contoso.FraudProtection.Web.Extensions
     {
         public static void Put<T>(this ITempDataDictionary tempData, string key, T value) where T : class
         {
-            tempData[key] = JsonConvert.SerializeObject(value);
+            tempData[key] = JsonSerializer.Serialize(value);
         }
 
         public static T Get<T>(this ITempDataDictionary tempData, string key) where T : class
         {
             tempData.TryGetValue(key, out object o);
-            return o == null ? null : JsonConvert.DeserializeObject<T>((string)o);
+            return o == null ? null : JsonSerializer.Deserialize<T>((string)o);
         }
     }
 }

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -25,7 +25,7 @@ namespace Contoso.FraudProtection.Web
     {
         private readonly IConfiguration Configuration;
 
-        public Startup(IWebHostEnvironment env, IConfiguration configuration)
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
         }

--- a/src/Web/ViewModels/FraudProtectionIOModel.cs
+++ b/src/Web/ViewModels/FraudProtectionIOModel.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace Contoso.FraudProtection.Web.ViewModels
 {
@@ -10,7 +10,17 @@ namespace Contoso.FraudProtection.Web.ViewModels
     {
         public const string TempDataKey = "FraudProtectionIOData";
 
-        public List<(string Request, string Response, string Name)> RequestResponsePairs = new List<(string Request, string Response, string Name)>();
+        public List<RequestResponsePair> RequestResponsePairs { get; set; } = new List<RequestResponsePair>();
+
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+
+        /// <summary>
+        /// For serialization only
+        /// </summary>
+        public FraudProtectionIOModel() { }
 
         public FraudProtectionIOModel(object request, object response, string name = "")
         {
@@ -19,11 +29,18 @@ namespace Contoso.FraudProtection.Web.ViewModels
 
         public void Add(object request, object response, string name = "")
         {
-            RequestResponsePairs.Add((
-                JsonConvert.SerializeObject(request, Formatting.Indented),
-                JsonConvert.SerializeObject(response, Formatting.Indented),
-                name
-            ));
+            RequestResponsePairs.Add(new RequestResponsePair {
+                Request = JsonSerializer.Serialize(request, JsonSerializerOptions),
+                Response = JsonSerializer.Serialize(response, JsonSerializerOptions),
+                Name = name
+            });
         }
+    }
+
+    public class RequestResponsePair
+    {
+        public string Request { get; set; }
+        public string Response { get; set; }
+        public string Name { get; set; }
     }
 }


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-migrate-from-newtonsoft-how-to

> System.Text.Json focuses primarily on performance, security, and standards compliance. It has some key differences in default behavior and doesn't aim to have feature parity with Newtonsoft.Json.
