### PR TITLE
Show Fraud Protection API errors and other errors to users.

### DIFF
--- a/src/ApplicationCore/Exceptions/FraudProtectionApiException.cs
+++ b/src/ApplicationCore/Exceptions/FraudProtectionApiException.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Net.Http;
+
+namespace Contoso.FraudProtection.ApplicationCore.Exceptions
+{
+    public class FraudProtectionApiException : Exception
+    {
+        public HttpResponseMessage Response { get; }
+
+        public FraudProtectionApiException()
+        {
+        }
+
+        public FraudProtectionApiException(HttpResponseMessage response) : base($"Fraud Protection API exception occurred!")
+        {
+            Response = response;
+        }
+
+        protected FraudProtectionApiException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+        }
+
+        public FraudProtectionApiException(string message) : base(message)
+        {
+        }
+
+        public FraudProtectionApiException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/Web/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Web/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using Contoso.FraudProtection.ApplicationCore.Exceptions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Contoso.FraudProtection.Web.Middleware
+{
+    public static class ExceptionHandlingMiddleware
+    {
+        public static void ConfigureExceptionHandler(this IApplicationBuilder app)
+        {
+            app.UseExceptionHandler(errorApp =>
+            {
+                errorApp.Run(async context =>
+                {
+                    context.Response.StatusCode = 500;
+                    context.Response.ContentType = "text/html";
+
+                    var sb = new StringBuilder();
+                    sb.AppendLine("<html lang='en'><body>");
+                    sb.AppendLine("<h2><a href='/'>&larr; Back home</a></h2>");
+
+                    var exceptionHandlerPathFeature = context.Features.Get<IExceptionHandlerPathFeature>();
+                    if (exceptionHandlerPathFeature?.Error is FraudProtectionApiException e)
+                    {
+                        sb.AppendLine("<h2>Fraud Protection API error!</h2>");
+                        using (e.Response)
+                        {
+                            sb.AppendLine("<h3>Request</h3>");
+                            sb.AppendLine("<pre>");
+                            sb.AppendLine(SanitizeAuthHeader(e.Response.RequestMessage.ToString()));
+                            sb.AppendLine(await ReadContent(e.Response.RequestMessage.Content));
+                            sb.AppendLine("</pre>");
+                            sb.AppendLine("<h3>Response</h3>");
+                            sb.AppendLine("<pre>");
+                            sb.AppendLine(e.Response.ToString());
+                            sb.AppendLine(await ReadContent(e.Response.Content));
+                            sb.AppendLine("</pre>");
+                        }
+                    }
+                    else
+                    {
+                        sb.AppendLine("<h2>Non Fraud Protection API error!</h2>");
+                        sb.AppendLine("<a href='https://github.com/microsoft/Dynamics-365-Fraud-Protection-Samples/issues/new/choose' target='_blank'>Consider reporting this sample app bug</a><br />");
+                        sb.AppendLine("<pre>");
+                        sb.AppendLine(exceptionHandlerPathFeature?.Error.ToString());
+                        sb.AppendLine("</pre>");
+                    }
+
+                    sb.AppendLine("</body></html>");
+
+                    await context.Response.WriteAsync(sb.ToString());
+                });
+            });
+        }
+
+        private static async Task<string> ReadContent(HttpContent content)
+        {
+            var str = await content.ReadAsStringAsync();
+            try
+            {
+                var obj = JsonSerializer.Deserialize<object>(str);
+                return JsonSerializer.Serialize(obj, new JsonSerializerOptions { WriteIndented = true });
+            }
+            catch (JsonException)
+            {
+                return str;
+            }
+        }
+
+        private static readonly Regex AuthRegex = new Regex("Authorization: bearer .*", RegexOptions.Compiled);
+        private static string SanitizeAuthHeader(string content) => AuthRegex.Replace(content, "Authorization: bearer [removed]");
+    }
+}

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -18,6 +18,7 @@ using Contoso.FraudProtection.Web.Interfaces;
 using Contoso.FraudProtection.Web.Services;
 using System;
 using Microsoft.Extensions.Hosting;
+using Contoso.FraudProtection.Web.Middleware;
 
 namespace Contoso.FraudProtection.Web
 {
@@ -112,14 +113,13 @@ namespace Contoso.FraudProtection.Web
         // This method gets called by the runtime.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            app.ConfigureExceptionHandler();
             if (env.IsDevelopment())
             {
-                app.UseDeveloperExceptionPage();
                 app.UseDatabaseErrorPage();
             }
             else
             {
-                app.UseExceptionHandler("/Catalog/Error");
                 app.UseHsts();
             }
 


### PR DESCRIPTION
This PR swaps out the default exception handling for custom error handling.  For Fraud Protection API errors it shows both the request and response full details to the user (sans the bearer token).  For other errors, it shows the stack trace with a link to open a bub in this repo (if they want to).  Here's what this looks like in practice.

![image](https://user-images.githubusercontent.com/165767/80653020-0083fc80-8a2e-11ea-878b-0ab23d0196ca.png)

![image](https://user-images.githubusercontent.com/165767/80652913-cfa3c780-8a2d-11ea-9e81-51749107e5b8.png)
