### PR TITLE
Update device attributes for Account and Purchase protection

### DIFF
--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Response/AccountProtectionDeviceAttributes.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/AccountProtection/Response/AccountProtectionDeviceAttributes.cs
@@ -1,22 +1,42 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response;
-
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection.Response
 {
-    public class AccountProtectionDeviceAttributes : DeviceAttributes
+    public class AccountProtectionDeviceAttributes
     {
+        public string BrowserUserAgent { get; set; }
+        public string BrowserUserAgentLanguages { get; set; }
+        public string Carrier { get; set; }
+        public string DataNetworkType { get; set; }
+        public string DeviceAsn { get; set; }
+        public string DeviceCity { get; set; }
+        public string DeviceCountryCode { get; set; }
+        public string DeviceId { get; set; }
+        public string DeviceModelName { get; set; }
+        public string DevicePostalCode { get; set; }
+        public string DeviceState { get; set; }
+        public string DeviceSystemVersion { get; set; }
+        public string IpRoutingType { get; set; }
+        public string IsDeviceEmulator { get; set; }
+        public string IsDeviceRooted { get; set; }
+        public string IsWifiEnabled { get; set; }
+        public string LocalIpv4 { get; set; }
+        public string LocalIpv6 { get; set; }
+        public string Platform { get; set; }
+        public string Proxy { get; set; }
         public string ProxyIp { get; set; }
-
-        public string RealtimeTimezoneOffset { get; set; }
-
-        public string TimeZone { get; set; }
-
-        public string Sld { get; set; }
-
         public string ProxyLastDetected { get; set; }
-
         public string ProxyType { get; set; }
+        public string RealtimeTimezoneOffset { get; set; }
+        public string SdkType { get; set; }
+        public string Sld { get; set; }
+        public string TcpDistance { get; set; }
+        public string TimeZone { get; set; }
+        public string TrueIp { get; set; }
+        public string UserAgentBrowser { get; set; }
+        public string UserAgentOperatingSystem { get; set; }
+        public string UserAgentPlatform { get; set; }
+
     }
 }

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/Enrichments.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/Enrichments.cs
@@ -3,7 +3,7 @@
 
 namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response
 {
-    public class Enrichments<TDeviceAttributes> where TDeviceAttributes : DeviceAttributes
+    public class Enrichments<TDeviceAttributes>
     {
         public TDeviceAttributes DeviceAttributes { get; set; }
 
@@ -20,8 +20,6 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
 
         public string CookieEnabled { get; set; }
 
-        public string DeviceAsn { get; set; }
-
         public string DeviceCity { get; set; }
 
         public string DeviceCountryCode { get; set; }
@@ -33,8 +31,6 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
         public string DeviceState { get; set; }
 
         public string FontsCount { get; set; }
-
-        public string IpRoutingType { get; set; }
 
         public string JavaScriptEnabled { get; set; }
 
@@ -50,17 +46,9 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
 
         public string ScreenResolution { get; set; }
 
-        public string TcpDistance { get; set; }
-
         public string TimeZoneOffset { get; set; }
 
         public string TrueIp { get; set; }
-
-        public string UserAgentBrowser { get; set; }
-
-        public string UserAgentOperatingSystem { get; set; }
-
-        public string UserAgentPlatform { get; set; }
 
         public string UserAgentType { get; set; }
     }


### PR DESCRIPTION
Updating our sample attributes to the latest for both account and purchase protection.  I've separate the two classes rather than trying to maintain 3 classes (a base set of attributes plus assessment specific attributes).  