### PR TITLE
Add DFP Fingerprinting to the custom assessment page

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 3.1.201
-    - name: Build with dotnet
+        dotnet-version: 6.0.x
+    - name: Build .NET
       run: dotnet build --configuration Release

--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/AssessmentResponse.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/AssessmentResponse.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response
+{
+    public class AssessmentResponse
+    {
+        public AssessmentMetadata Metadata { get; set; }
+
+        public AssessmentDecisionDetails DecisionDetails { get; set; }
+
+        public List<RuleEvaluation> RuleEvaluations { get; set; }
+
+        public List<AssessmentScores> Scores { get; set; }
+
+        public IDictionary<string, object> CustomProperties { get; set; }
+    }
+
+    public class AssessmentMetadata
+    {
+        public string EventId { get; set; }
+
+        public string SessionId { get; set; }
+
+        public string GdprId { get; set; }
+
+        public bool IsTest { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        public DateTimeOffset ProcessedDateTime { get; set; }
+
+        public string HierarchyPath { get; set; }
+
+        public string EventType { get; set; }
+
+        public string CorrelationId { get; set; }
+    }
+
+    public class AssessmentDecisionDetails
+    {
+        public string MerchantRuleDecision { get; set; }
+
+        public string ChallengeType { get; set; }
+
+        public string Rule { get; set; }
+
+        public string ClauseName { get; set; }
+
+        public List<string> Reasons { get; set; }
+
+        public List<string> SupportMessages { get; set; }
+    }
+
+    public class AssessmentScores
+    {
+        public string ScoreType { get; set; }
+
+        public double ScoreValue { get; set; }
+
+        public string Reason { get; set; }
+    }
+}

--- a/src/ApplicationCore/Interfaces/IFraudPreventionService.cs
+++ b/src/ApplicationCore/Interfaces/IFraudPreventionService.cs
@@ -3,6 +3,7 @@
 
 using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels;
 using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection.Response;
+using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response;
 using Microsoft.Dynamics.FraudProtection.Models.BankEventEvent;
 using Microsoft.Dynamics.FraudProtection.Models.ChargebackEvent;
 using Microsoft.Dynamics.FraudProtection.Models.LabelEvent;
@@ -42,7 +43,9 @@ namespace Contoso.FraudProtection.ApplicationCore.Interfaces
 
         Task<Response> PostSignIn(AccountProtection.SignIn request, string correlationId, string envId);
 
-        Task<Response> PostCustomAssessment(CustomAssessment assessment, string correlationId, string envId, bool useV2);
+        Task<Response> PostCustomAssessment(CustomAssessment assessment, string correlationId, string envId);
+
+        Task<AssessmentResponse> PostAssessment(CustomAssessment assessment, string correlationId, string envId);
     }
 
     #endregion

--- a/src/Infrastructure/Services/FraudProtectionService.cs
+++ b/src/Infrastructure/Services/FraudProtectionService.cs
@@ -3,6 +3,7 @@
 
 using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels;
 using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.AccountProtection.Response;
+using Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiModels.Response;
 using Contoso.FraudProtection.ApplicationCore.Exceptions;
 using Contoso.FraudProtection.ApplicationCore.Interfaces;
 using Microsoft.Dynamics.FraudProtection.Models;
@@ -166,12 +167,20 @@ namespace Contoso.FraudProtection.Infrastructure.Services
             return await Read<ResponseSuccess>(response);
         }
 
-        public async Task<Response> PostCustomAssessment(CustomAssessment assessment, string correlationId, string envId, bool useV2)
+        public async Task<Response> PostCustomAssessment(CustomAssessment assessment, string correlationId, string envId)
         {
-            string endpoint = string.Format(useV2 ? _settings.Endpoints.Assessment : _settings.Endpoints.CustomAssessment, assessment.ApiName);
+            string endpoint = string.Format(_settings.Endpoints.CustomAssessment, assessment.ApiName);
 
             var response = await PostAsync(endpoint, assessment.Payload, correlationId, envId, true);
             return await Read<ResponseSuccess>(response);
+        }
+
+        public async Task<AssessmentResponse> PostAssessment(CustomAssessment assessment, string correlationId, string envId)
+        {
+            string endpoint = string.Format(_settings.Endpoints.Assessment, assessment.ApiName);
+
+            var response = await PostAsync(endpoint, assessment.Payload, correlationId, envId, true);
+            return await Read<AssessmentResponse>(response);
         }
     }
     #endregion

--- a/src/Web/ViewModels/Account/LoginViewModel.cs
+++ b/src/Web/ViewModels/Account/LoginViewModel.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using Contoso.FraudProtection.Web.ViewModels.Shared;
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Contoso.FraudProtection.Web.ViewModels.Account

--- a/src/Web/ViewModels/CustomAssessmentViewModel.cs
+++ b/src/Web/ViewModels/CustomAssessmentViewModel.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using Contoso.FraudProtection.Web.ViewModels.Shared;
 using System.ComponentModel.DataAnnotations;
 
 namespace Contoso.FraudProtection.Web.ViewModels
@@ -15,6 +16,8 @@ namespace Contoso.FraudProtection.Web.ViewModels
 
         [Required]
         public EndpointVersion Version { get; set; }
+
+        public DeviceFingerPrintingViewModel DeviceFingerPrinting { get; set; }
     }
 
     public enum EndpointVersion

--- a/src/Web/Views/Account/CustomAssessment.cshtml
+++ b/src/Web/Views/Account/CustomAssessment.cshtml
@@ -13,13 +13,32 @@
 }
 
 <div class="container">
-    <form asp-controller="Account" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
+    <form asp-controller="Account" method="post" class="form-horizontal">
+        @Html.HiddenFor(m => m.DeviceFingerPrinting.SessionId)
+
         <div class="row">
             <div asp-validation-summary="All" class="text-danger"></div>
 
             <div class="col-xs-12">
                 <section>
                     <h3>Custom Assessment</h3>
+                    <div class="form-group">
+                        <div class="col-xs-12">
+                            <div>Use <b>@@deviceContextId</b> in your request to have it replaced with the DFP Fingerprinting session ID.</div>
+                            <div>Use <b>@@deviceIpAddress</b> in your request to have it replaced with the client's IP address.</div>
+                            <pre>
+ {
+     ...
+     "deviceContext": {
+         "deviceContextId": "@@deviceContextId",
+         "ipAddress": "@@deviceIpAddress",
+         ...
+     }
+     ...
+ }
+                            </pre>
+                        </div>
+                    </div>
                     <div class="form-group">
                         <div class="col-xs-12">
                             <label for="ApiName">API Name</label>
@@ -57,3 +76,5 @@
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }
+
+<partial name="_DeviceFingerPrinting" model="Model.DeviceFingerPrinting" />


### PR DESCRIPTION
- Call DFP Fingerprinting from the custom assessment page
- Allows using '@deviceContextId' and '@deviceIpAddress' to have the app automatically fill those in in a request.
- Updates the V2 assessment response contract

Sending the request:
![image](https://user-images.githubusercontent.com/165767/189501345-8e8984f0-a84e-403b-b672-a62bde8c37ba.png)

Request/Response display:
![image](https://user-images.githubusercontent.com/165767/189501375-e145ef6c-7306-4e80-a443-5797c157122d.png)
