### PR TITLE
Display latency info for API calls 

### DIFF
--- a/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SampleResponse.cs
+++ b/src/ApplicationCore/Entities/FraudProtectionApiModels/Response/SampleResponse.cs
@@ -6,6 +6,8 @@ namespace Contoso.FraudProtection.ApplicationCore.Entities.FraudProtectionApiMod
     public class SampleResponseRaw
     {
         public object RawData { get; set; }
+
+        public long ResponseTime { get; set; }
     }
 
     public class SampleResponse<T> : SampleResponseRaw

--- a/src/Infrastructure/Services/FraudProtectionService.cs
+++ b/src/Infrastructure/Services/FraudProtectionService.cs
@@ -112,100 +112,70 @@ namespace Contoso.FraudProtection.Infrastructure.Services
             };
         }
 
-        private async Task<SampleResponse<T>> Read<T>(HttpResponseMessage response) where T : new()
-        {
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new FraudProtectionApiException(response);
-            }
-
-            var content = await response.Content.ReadAsStringAsync();
-            response.Dispose();
-
-            return new SampleResponse<T>
-            {
-                Data = JsonSerializer.Deserialize<T>(content, _responseDeserializationOptions),
-                RawData = JsonSerializer.Deserialize<object>(content, _responseDeserializationOptions),
-            };
-        }
-
         public async Task<SampleResponse<PurchaseResponse>> PostPurchase(Purchase purchase, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.Purchase, purchase, correlationId, envId);
-            return await Read<PurchaseResponse>(response);
+            return await CallAndRead<PurchaseResponse>(() => PostAsync(_settings.Endpoints.Purchase, purchase, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostRefund(Refund refund, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.Refund, refund, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.Refund, refund, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostUser(User userAccount, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.UpdateAccount, userAccount, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.UpdateAccount, userAccount, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostBankEvent(BankEvent bankEvent, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.BankEvent, bankEvent, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.BankEvent, bankEvent, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostChargeback(Chargeback chargeback, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.Chargeback, chargeback, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.Chargeback, chargeback, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostPurchaseStatus(PurchaseStatusEvent purchaseStatus, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.PurchaseStatus, purchaseStatus, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.PurchaseStatus, purchaseStatus, correlationId, envId));
         }
 
         public async Task<SampleResponse<Response>> PostSignup(AccountProtection.SignUp signup, string correlationId, string envId)
         {
             var endpoint = string.Format(_settings.Endpoints.SignupAP, signup.Metadata.SignUpId);
-
-            var response = await PostAsync(endpoint, signup, correlationId, envId);
-            return await Read<Response>(response);
+            return await CallAndRead<Response>(() => PostAsync(endpoint, signup, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostSignupStatus(SignupStatusEvent signupStatus, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.SignupStatus, signupStatus, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.SignupStatus, signupStatus, correlationId, envId));
         }
 
         public async Task<SampleResponse<FraudProtectionResponse>> PostLabel(Label label, string correlationId, string envId)
         {
-            var response = await PostAsync(_settings.Endpoints.Label, label, correlationId, envId);
-            return await Read<FraudProtectionResponse>(response);
+            return await CallAndRead<FraudProtectionResponse>(() => PostAsync(_settings.Endpoints.Label, label, correlationId, envId));
         }
 
         public async Task<SampleResponse<Response>> PostSignIn(AccountProtection.SignIn signIn, string correlationId, string envId)
         {
             var endpoint = string.Format(_settings.Endpoints.SignInAP, signIn.Metadata.LoginId);
 
-            var response = await PostAsync(endpoint, signIn, correlationId, envId);
-            return await Read<Response>(response);
+            return await CallAndRead<Response>(() => PostAsync(endpoint, signIn, correlationId, envId));
         }
 
         public async Task<SampleResponse<Response>> PostCustomAssessment(CustomAssessment assessment, string correlationId, string envId)
         {
             var endpoint = string.Format(_settings.Endpoints.CustomAssessment, assessment.ApiName);
 
-            return await CallAndRead<Response>(async () => await PostAsync(endpoint, assessment.Payload, correlationId, envId, true));
+            return await CallAndRead<Response>(() => PostAsync(endpoint, assessment.Payload, correlationId, envId, true));
         }
 
         public async Task<SampleResponse<AssessmentResponse>> PostAssessment(CustomAssessment assessment, string correlationId, string envId)
         {
             var endpoint = string.Format(_settings.Endpoints.Assessment, assessment.ApiName);
-
-            var response = await PostAsync(endpoint, assessment.Payload, correlationId, envId, true);
-            return await CallAndRead<AssessmentResponse>(async () => await PostAsync(endpoint, assessment.Payload, correlationId, envId, true));
+            return await CallAndRead<AssessmentResponse>(() => PostAsync(endpoint, assessment.Payload, correlationId, envId, true));
         }
     }
     #endregion

--- a/src/Web/ViewModels/FraudProtectionIOModel.cs
+++ b/src/Web/ViewModels/FraudProtectionIOModel.cs
@@ -38,7 +38,7 @@ namespace Contoso.FraudProtection.Web.ViewModels
                 Request = skipSerialization ? request as string : JsonSerializer.Serialize(request, JsonSerializerOptions),
                 Response = JsonSerializer.Serialize(response.RawData, JsonSerializerOptions),
                 Name = name,
-                CallTime = response.ResponseTime
+                ResponseTime = response.ResponseTime
             });
         }
     }
@@ -48,6 +48,6 @@ namespace Contoso.FraudProtection.Web.ViewModels
         public string Request { get; set; }
         public string Response { get; set; }
         public string Name { get; set; }
-        public long CallTime {  get; set; }
+        public long ResponseTime {  get; set; }
     }
 }

--- a/src/Web/ViewModels/FraudProtectionIOModel.cs
+++ b/src/Web/ViewModels/FraudProtectionIOModel.cs
@@ -37,7 +37,8 @@ namespace Contoso.FraudProtection.Web.ViewModels
             {
                 Request = skipSerialization ? request as string : JsonSerializer.Serialize(request, JsonSerializerOptions),
                 Response = JsonSerializer.Serialize(response.RawData, JsonSerializerOptions),
-                Name = name
+                Name = name,
+                CallTime = response.ResponseTime
             });
         }
     }
@@ -47,5 +48,6 @@ namespace Contoso.FraudProtection.Web.ViewModels
         public string Request { get; set; }
         public string Response { get; set; }
         public string Name { get; set; }
+        public long CallTime {  get; set; }
     }
 }

--- a/src/Web/Views/Shared/_FraudProtectionIO.cshtml
+++ b/src/Web/Views/Shared/_FraudProtectionIO.cshtml
@@ -25,6 +25,7 @@
                 <div class="col-md-12">
                     <section>
                         @if (io.Name != null) { <h3>@io.Name</h3> }
+                        @if (@io.ResponseTime > 0) { <h5>API call duration: @io.ResponseTime ms</h5> }
                         <div class="col-md-6">
                             <h4>Fraud Protection Request</h4>
                             <pre>@io.Request</pre>
@@ -35,12 +36,7 @@
                         </div>
                     </section>
                 </div>
-                @if (@io.CallTime > 0)
-                {
-                    <div class="row">
-                        <h5>The above call took @io.CallTime ms</h5>
-                    </div>
-                }
+                
             </div>
         </div>
     }

--- a/src/Web/Views/Shared/_FraudProtectionIO.cshtml
+++ b/src/Web/Views/Shared/_FraudProtectionIO.cshtml
@@ -35,6 +35,12 @@
                         </div>
                     </section>
                 </div>
+                @if (@io.CallTime > 0)
+                {
+                    <div class="row">
+                        <h5>The above call took @io.CallTime ms</h5>
+                    </div>
+                }
             </div>
         </div>
     }


### PR DESCRIPTION
Display the elapsed time from calling the BE API to receiving a response. 
Modify the `Read` method to call the BE API as well so it can track the elapsed time.

![image](https://github.com/microsoft/Dynamics-365-Fraud-Protection-Samples/assets/19998479/df80346f-14cd-4389-923f-3e225335b2b9)
