### PR TITLE
Support certificate location change and SNI

### DIFF
--- a/src/Infrastructure/Services/FraudProtectionSettings.cs
+++ b/src/Infrastructure/Services/FraudProtectionSettings.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+using System.Security.Cryptography.X509Certificates;
+
 namespace Contoso.FraudProtection.Infrastructure.Services
 {
     #region Fraud Protection Service
@@ -34,8 +36,10 @@ namespace Contoso.FraudProtection.Infrastructure.Services
         public string Resource { get; set; }
         public string ClientId { get; set; }
         public string Authority { get; set; }
-        public string CertificateThumbprint { get; set; }
         public string ClientSecret { get; set; }
+        public string CertificateThumbprint { get; set; }
+        public StoreLocation CertificateLocation { get; set; }
+        public bool? UseSNI { get; set; }
     }
     #endregion
 }

--- a/src/Infrastructure/Services/TokenProviderService.cs
+++ b/src/Infrastructure/Services/TokenProviderService.cs
@@ -33,8 +33,8 @@ namespace Contoso.FraudProtection.Infrastructure.Services
 
             if (settings.CertificateThumbprint != "")
             {
-                var x509Cert = CertificateUtility.GetByThumbprint(settings.CertificateThumbprint);
-                builder = builder.WithCertificate(x509Cert);
+                var x509Cert = CertificateUtility.GetByThumbprint(settings.CertificateThumbprint, settings.CertificateLocation);
+                builder = builder.WithCertificate(x509Cert, settings.UseSNI ?? false);
             }
             else
             {

--- a/src/Infrastructure/Utilities/CertificateUtility.cs
+++ b/src/Infrastructure/Utilities/CertificateUtility.cs
@@ -8,9 +8,9 @@ namespace Contoso.FraudProtection.Infrastructure.Utilities
 {
     public static class CertificateUtility
     {
-        public static X509Certificate2 GetCertificateBy<T>(X509FindType findType, T findValue)
+        private static X509Certificate2 GetCertificateBy<T>(X509FindType findType, T findValue, StoreLocation location)
         {
-            var certStore = new X509Store(StoreLocation.CurrentUser);
+            var certStore = new X509Store(location);
             certStore.Open(OpenFlags.ReadOnly);
 
             X509Certificate2Collection certs = certStore.Certificates.Find(findType, findValue, false);
@@ -24,9 +24,9 @@ namespace Contoso.FraudProtection.Infrastructure.Utilities
             }
         }
 
-        public static X509Certificate2 GetByThumbprint(string thumbprint)
+        public static X509Certificate2 GetByThumbprint(string thumbprint, StoreLocation location)
         {
-            return GetCertificateBy(X509FindType.FindByThumbprint, thumbprint);
+            return GetCertificateBy(X509FindType.FindByThumbprint, thumbprint, location);
         }
     }
 }

--- a/src/Web/Views/Shared/_DeviceFingerPrinting.cshtml
+++ b/src/Web/Views/Shared/_DeviceFingerPrinting.cshtml
@@ -4,12 +4,13 @@
 *@
 
 @using Contoso.FraudProtection.Web.ViewModels.Shared
+@using Microsoft.AspNetCore.Http
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
 @{
     @model DeviceFingerPrintingViewModel
     var fingerprintingDomain = Configuration.GetSection("FraudProtectionSettings")["DeviceFingerprintingDomain"];
-    var fingerprintingCustomerId = Configuration.GetSection("FraudProtectionSettings")["DeviceFingerprintingCustomerId"];
+    var fingerprintingCustomerId = @Context.Session.GetString("envId") ?? Configuration.GetSection("FraudProtectionSettings")["DeviceFingerprintingCustomerId"];
     var fingerprintingSessionId = Model.SessionId;
 }
 


### PR DESCRIPTION
For security reasons, these changes support the ability to change the certificate location and enable SNI.  There is also a small fix for fingerprinting, where the correct environment will be passed to fingerprinting if a non-default environment is being used.