### PR TITLE
[Security] Update all NuGets and fix any build warnings

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,10 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+    - uses: actions/checkout@v4
       with:
-        dotnet-version: 6.0.x
+        fetch-depth: 0
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+    
     - name: Build .NET
       run: dotnet build --configuration Release

--- a/src/ApplicationCore/ApplicationCore.csproj
+++ b/src/ApplicationCore/ApplicationCore.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Contoso.FraudProtection.ApplicationCore</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-    <PackageReference Include="System.Text.Json" Version="6.0.6" />
+	<PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationCore/ApplicationCore.csproj
+++ b/src/ApplicationCore/ApplicationCore.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Security.Claims" Version="4.3.0" />
-	<PackageReference Include="System.Text.Json" Version="6.0.6" />
+	<PackageReference Include="System.Text.Json" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApplicationCore/Exceptions/BasketNotFoundException.cs
+++ b/src/ApplicationCore/Exceptions/BasketNotFoundException.cs
@@ -11,10 +11,6 @@ namespace Contoso.FraudProtection.ApplicationCore.Exceptions
         {
         }
 
-        protected BasketNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
-        {
-        }
-
         public BasketNotFoundException(string message) : base(message)
         {
         }

--- a/src/ApplicationCore/Exceptions/FraudProtectionApiException.cs
+++ b/src/ApplicationCore/Exceptions/FraudProtectionApiException.cs
@@ -19,10 +19,6 @@ namespace Contoso.FraudProtection.ApplicationCore.Exceptions
             Response = response;
         }
 
-        protected FraudProtectionApiException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
-        {
-        }
-
         public FraudProtectionApiException(string message) : base(message)
         {
         }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -7,10 +7,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.72.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Contoso.FraudProtection.Infrastructure</RootNamespace>
   </PropertyGroup>
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.72.0" />

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.3" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.40.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.72.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApplicationCore\ApplicationCore.csproj" />

--- a/src/Web/Areas/Admin/Views/Shared/_LoginPartial.cshtml
+++ b/src/Web/Areas/Admin/Views/Shared/_LoginPartial.cshtml
@@ -8,7 +8,7 @@
 {
     <section class="col-lg-4 col-md-5 col-xs-12">
         <div class="esh-identity">
-            <form asp-area="" asp-controller="Account" asp-action="SignOut" method="post" id="logoutForm" class="navbar-right">
+            <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" class="navbar-right">
                 <div class="dropdown">
                     <a href="#" data-toggle="dropdown" class="dropdown-toggle">@Context.User.Identity.Name <b class="caret"></b></a>
                     <ul class="dropdown-menu">

--- a/src/Web/Controllers/AccountController.cs
+++ b/src/Web/Controllers/AccountController.cs
@@ -188,7 +188,7 @@ namespace Contoso.FraudProtection.Web.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> SignOut()
+        public async Task<ActionResult> Logout()
         {
             await _signInManager.SignOutAsync();
 

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -108,8 +108,6 @@ namespace Contoso.FraudProtection.Web
 
             services.AddControllersWithViews();
             services.AddSession();
-
-            services.AddDatabaseDeveloperPageExceptionFilter();
         }
 
         // This method gets called by the runtime.
@@ -117,11 +115,7 @@ namespace Contoso.FraudProtection.Web
         {
             app.ConfigureExceptionHandler();
 
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
+            if (!env.IsDevelopment())
             {
                 app.UseHsts();
             }

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -77,7 +77,7 @@ namespace Contoso.FraudProtection.Web
                 options.Cookie.HttpOnly = true;
                 options.ExpireTimeSpan = TimeSpan.FromHours(1);
                 options.LoginPath = "/Account/Signin";
-                options.LogoutPath = "/Account/Signout";
+                options.LogoutPath = "/Account/Logout";
                 options.Cookie = new CookieBuilder
                 {
                     IsEssential = true // required for auth to work without explicit user consent; adjust to suit your privacy policy
@@ -98,7 +98,7 @@ namespace Contoso.FraudProtection.Web
 
             services.AddScoped(typeof(IAppLogger<>), typeof(LoggerAdapter<>));
             services.AddTransient<IEmailSender, EmailSender>();
-            
+
             services.Configure<TokenProviderServiceSettings>(Configuration.GetSection("FraudProtectionSettings:TokenProviderConfig"));
             services.AddSingleton<ITokenProvider, TokenProviderService>();
             services.Configure<FraudProtectionSettings>(Configuration.GetSection("FraudProtectionSettings"));
@@ -108,15 +108,18 @@ namespace Contoso.FraudProtection.Web
 
             services.AddControllersWithViews();
             services.AddSession();
+
+            services.AddDatabaseDeveloperPageExceptionFilter();
         }
 
         // This method gets called by the runtime.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.ConfigureExceptionHandler();
+
             if (env.IsDevelopment())
             {
-                app.UseDatabaseErrorPage();
+                app.UseDeveloperExceptionPage();
             }
             else
             {
@@ -130,7 +133,7 @@ namespace Contoso.FraudProtection.Web
             app.UseAuthorization();
             app.UseSession();
 
-            app.UseEndpoints(routes => 
+            app.UseEndpoints(routes =>
             {
                 routes.MapControllerRoute(
                     name: "areaRoute",

--- a/src/Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Web/Views/Shared/_LoginPartial.cshtml
@@ -8,7 +8,7 @@
 {
     <section class="col-lg-5 col-md-5 col-xs-12">
         <div class="esh-identity">
-            <form asp-area="" asp-controller="Account" asp-action="SignOut" method="post" id="logoutForm" class="navbar-right">
+            <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" class="navbar-right">
                 <div class="row">
                     <div class="col-xs-6">
                         <a asp-controller="Account" asp-action="CustomAssessment" class="text">

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" Condition="'$(Configuration)'=='Release'" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" PrivateAssets="All" />
     </ItemGroup>
   <ItemGroup>
     <Folder Include="Views\Catalog\" />

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" Condition="'$(Configuration)'=='Release'" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" PrivateAssets="All" />

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Contoso.FraudProtection.Web</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
I verified the app still builds (in Debug and Release) and that users can still call DFP APIs, create accounts, sign in and out, and manage their account.  Also, purchase labels, returns, chargebacks were tested. 

Updated the GitHub action too.  It still succeeds, but now with no warnings:
<img width="1874" alt="image" src="https://github.com/user-attachments/assets/853dc2c3-520a-4ac4-acb1-5f82e57a4c96" />
